### PR TITLE
(support): SWT version selected for Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<description>task notifier client</description>
 
 	<properties>
-		<swt.version>4.3</swt.version>
+		<swt.version>3.116.0</swt.version>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 	</properties>
@@ -63,9 +63,15 @@
 			<version>2.2.7</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.swt</groupId>
+			<groupId>org.eclipse.platform</groupId>
 			<artifactId>${swt.artifactId}</artifactId>
 			<version>${swt.version}</version>
+    		<exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.platform</groupId>
+                    <artifactId>org.eclipse.swt</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>javax.xml.ws</groupId>
@@ -129,6 +135,7 @@
 		    </activation>
 		    <properties>
 		        <swt.artifactId>org.eclipse.swt.gtk.linux.x86</swt.artifactId>
+                <swt.version>3.106.0</swt.version>
 		    </properties>
 		</profile>
 		<profile>
@@ -141,6 +148,7 @@
 		    </activation>
 		    <properties>
 		        <swt.artifactId>org.eclipse.swt.gtk.linux.x86</swt.artifactId>
+                <swt.version>3.106.0</swt.version>
 		    </properties>
 		</profile>
 		<profile>
@@ -153,8 +161,21 @@
 		    </activation>
 		    <properties>
 		        <swt.artifactId>org.eclipse.swt.gtk.linux.x86_64</swt.artifactId>
+                <swt.version>3.106.0</swt.version>
 		    </properties>
 		</profile>
+    	<profile>
+            <id>linux-aarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <swt.artifactId>org.eclipse.swt.gtk.linux.aarch64</swt.artifactId>
+            </properties>
+        </profile>
     </profiles>
 
 	<build>


### PR DESCRIPTION
  1. SWT version updated to 3.106.0 for Linux on x86, AMD, and i386 architectures
  2. Added the linux-aarch64 profile; SWT version for this architecture updated to 3.116.0